### PR TITLE
deps: bump PyTorch version to 1.12

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
         uses: Jimver/cuda-toolkit@v0.2.7
         id: cuda-toolkit
         with:
-          cuda: "11.3.1"
+          cuda: "11.6.2"
           method: network
           sub-packages: '["nvcc"]'
       - run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: pypi
+name: PyPI
 
 on:
   release:
@@ -90,8 +90,9 @@ jobs:
 
       - name: Publish to PyPI
         env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          TWINE_USERNAME: "__token__"
+          TWINE_PASSWORD: ${{ secrets.PYPI_UPLOAD_TOKEN }}
         run: |
           "${DEFAULT_PYTHON}" -m pip install --upgrade twine
-          "${DEFAULT_PYTHON}" -m twine upload dist/*
+          "${DEFAULT_PYTHON}" -m twine upload --repository testpypi dist/*
+          "${DEFAULT_PYTHON}" -m twine upload --repository pypi dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         uses: Jimver/cuda-toolkit@v0.2.7
         id: cuda-toolkit
         with:
-          cuda: "11.3.1"
+          cuda: "11.6.2"
           method: network
           sub-packages: '["nvcc"]'
       - run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
         uses: Jimver/cuda-toolkit@v0.2.7
         id: cuda-toolkit
         with:
-          cuda: "11.3.1"
+          cuda: "11.6.2"
           method: network
           sub-packages: '["nvcc"]'
       - run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,11 +77,11 @@ system(
     COMMAND "${PYTHON_EXECUTABLE}" -c "print(__import__('platform').python_version())"
 )
 
-message("-- Use Python version: ${PYTHON_VERSION}")
-message("-- Use Python executable: \"${PYTHON_EXECUTABLE}\"")
+message(STATUS "Use Python version: ${PYTHON_VERSION}")
+message(STATUS "Use Python executable: \"${PYTHON_EXECUTABLE}\"")
 
 if(NOT DEFINED PYTHON_INCLUDE_DIR)
-    message("-- Auto detecting Python include directory...")
+    message(STATUS "Auto detecting Python include directory...")
     system(
         STRIP OUTPUT_VARIABLE PYTHON_INCLUDE_DIR
         COMMAND "${PYTHON_EXECUTABLE}" -c "print(__import__('sysconfig').get_path('include'))"
@@ -89,16 +89,16 @@ if(NOT DEFINED PYTHON_INCLUDE_DIR)
 endif()
 
 if("${PYTHON_INCLUDE_DIR}" STREQUAL "")
-    message(FATAL_ERROR "-- Python include directory not found")
+    message(FATAL_ERROR "Python include directory not found")
 else()
-    message("-- Detected Python include directory: \"${PYTHON_INCLUDE_DIR}\"")
+    message(STATUS "Detected Python include directory: \"${PYTHON_INCLUDE_DIR}\"")
     include_directories(${PYTHON_INCLUDE_DIR})
 endif()
 
 set(PYBIND11_PYTHON_VERSION "${PYTHON_VERSION}")
 
 if(NOT DEFINED PYBIND11_CMAKE_DIR)
-    message("-- Auto detecting pybind11 CMake directory...")
+    message(STATUS "Auto detecting pybind11 CMake directory...")
     system(
         STRIP OUTPUT_VARIABLE PYBIND11_CMAKE_DIR
         COMMAND "${PYTHON_EXECUTABLE}" -m pybind11 --cmakedir
@@ -106,14 +106,14 @@ if(NOT DEFINED PYBIND11_CMAKE_DIR)
 endif()
 
 if("${PYBIND11_CMAKE_DIR}" STREQUAL "")
-    message(FATAL_ERROR "-- Pybind11 CMake directory not found")
+    message(FATAL_ERROR "Pybind11 CMake directory not found")
 else()
-    message("-- Detected Pybind11 CMake directory: \"${PYBIND11_CMAKE_DIR}\"")
+    message(STATUS "Detected Pybind11 CMake directory: \"${PYBIND11_CMAKE_DIR}\"")
     find_package(pybind11 CONFIG PATHS "${PYBIND11_CMAKE_DIR}")
 endif()
 
 if(NOT DEFINED TORCH_INCLUDE_PATH)
-    message("-- Auto detecting PyTorch include directory...")
+    message(STATUS "Auto detecting PyTorch include directory...")
     system(
         STRIP OUTPUT_VARIABLE TORCH_INCLUDE_PATH
         COMMAND "${PYTHON_EXECUTABLE}" -c "print('\\\;'.join(__import__('torch.utils.cpp_extension', fromlist=[None]).include_paths()))"
@@ -121,14 +121,14 @@ if(NOT DEFINED TORCH_INCLUDE_PATH)
 endif()
 
 if("${TORCH_INCLUDE_PATH}" STREQUAL "")
-    message(FATAL_ERROR "-- Torch include directory not found")
+    message(FATAL_ERROR "Torch include directory not found")
 else()
-    message("-- Detected Torch include directory: \"${TORCH_INCLUDE_PATH}\"")
+    message(STATUS "Detected Torch include directory: \"${TORCH_INCLUDE_PATH}\"")
     include_directories(${TORCH_INCLUDE_PATH})
 endif()
 
 if(NOT DEFINED TORCH_LIBRARY_PATH)
-    message("-- Auto detecting PyTorch library directory...")
+    message(STATUS "Auto detecting PyTorch library directory...")
     system(
         STRIP OUTPUT_VARIABLE TORCH_LIBRARY_PATH
         COMMAND "${PYTHON_EXECUTABLE}" -c "print('\\\;'.join(__import__('torch.utils.cpp_extension', fromlist=[None]).library_paths()))"
@@ -136,9 +136,9 @@ if(NOT DEFINED TORCH_LIBRARY_PATH)
 endif()
 
 if("${TORCH_LIBRARY_PATH}" STREQUAL "")
-    message(FATAL_ERROR "-- Torch library directory not found")
+    message(FATAL_ERROR "Torch library directory not found")
 else()
-    message("-- Detected Torch library directory: \"${TORCH_LIBRARY_PATH}\"")
+    message(STATUS "Detected Torch library directory: \"${TORCH_LIBRARY_PATH}\"")
 endif()
 
 unset(TORCH_LIBRARIES)
@@ -148,7 +148,7 @@ foreach(VAR_PATH ${TORCH_LIBRARY_PATH})
     list(APPEND TORCH_LIBRARIES "${TORCH_LIBRARY}")
 endforeach()
 
-message("-- Detected Torch libraries: \"${TORCH_LIBRARIES}\"")
+message(STATUS "Detected Torch libraries: \"${TORCH_LIBRARIES}\"")
 
 add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
 

--- a/conda-recipe.yaml
+++ b/conda-recipe.yaml
@@ -1,6 +1,6 @@
 # Create virtual environment with command:
 #
-#   conda env create --file conda-recipe.yaml
+#   $ CONDA_OVERRIDE_CUDA=11.7 conda env create --file conda-recipe.yaml
 #
 
 name: torchopt
@@ -8,36 +8,40 @@ name: torchopt
 channels:
   - pytorch
   - defaults
+  - nvidia/label/cuda-11.6.2
   - nvidia
   - conda-forge
 
 dependencies:
   - python = 3.8
+  - pip
 
   # Learning
-  - pytorch::pytorch = 1.11
+  - pytorch::pytorch = 1.12
   - pytorch::torchvision
-  - jax
-  - jaxlib
-  - tensorboard
-  - wandb
+  - pytorch::pytorch-mutex = *=*cuda*
   - pip:
       - functorch
+  - jax
+  - jaxlib >= 0.3=*cuda*
+  - optax
+  - tensorboard
+  - wandb
 
   # Device select
-  - nvidia::cudatoolkit = 11.3.1
+  - nvidia::cudatoolkit = 11.6
   - cudnn
 
   # Build toolkit
   - cmake >= 3.4
   - make
   - cxx-compiler
-  - gxx >= 6.0, < 12.0
-  - nvidia/label/cuda-11.3.1::cuda-minimal-build
+  - gxx = 10
+  - nvidia/label/cuda-11.6.2::cuda-nvcc
+  - nvidia/label/cuda-11.6.2::cuda-cudart-dev
   - pybind11
 
   # Misc
-  - pip
   - typing-extensions
   - numpy
   - matplotlib-base

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-torch==1.11
-jax[cpu]
+torch == 1.12
+jax[cpu] >= 0.3
 numpy
 graphviz
 typing-extensions

--- a/setup.py
+++ b/setup.py
@@ -101,16 +101,16 @@ setup(
         CMakeExtension('torchopt._lib.adam_op', source_dir=HERE)
     ],
     setup_requires=[  # for `torch.utils.cpp_extension`
-        'torch==1.11',
+        'torch == 1.12',
         'numpy',
         'pybind11',
     ],
     install_requires=[
-        'torch==1.11',
-        'jax[cpu]',
+        'torch == 1.12',
+        'jax[cpu] >= 0.3',
         'numpy',
         'graphviz',
         'typing-extensions',
     ],
-    python_requires='>=3.7'
+    python_requires='>= 3.7'
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,10 +1,10 @@
---extra-index-url https://download.pytorch.org/whl/cu113
-torch==1.11
+--extra-index-url https://download.pytorch.org/whl/cu116
+torch == 1.12
 torchvision
 functorch
 
 --requirement ../requirements.txt
 
 pytest
-pytest_cov
-pytest_xdist
+pytest-cov
+pytest-xdist

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,3 +8,12 @@ functorch
 pytest
 pytest-cov
 pytest-xdist
+isort
+yapf
+mypy
+flake8
+flake8-bugbear
+doc8
+pydocstyle
+pyenchant
+cpplint


### PR DESCRIPTION
## Description

Update dependency PyTorch to 1.12 due to packaging issue for `functorch`. See `functorch`'s release note: https://github.com/pytorch/functorch/releases/tag/v0.2.0 and issue pytorch/pytorch#80489.

Command:

```bash
CONDA_OVERRIDE_CUDA=11.7 conda env create --file conda-recipe.yaml
conda activate torchopt
pip3 install -e .
```

while create a dev environment with CUDA Toolkit 11.6.0, PyTorch (CUDA) 1.12.0, functorch 0.2, and JAX (CUDA) 0.3.14.

Stdout:

```console
$ CONDA_OVERRIDE_CUDA=11.7 conda env create -f conda-recipe.yaml
Collecting package metadata (repodata.json): done
Solving environment: done
Preparing transaction: done
Verifying transaction: done
Executing transaction: done
Collecting package metadata (repodata.json): done
Solving environment: done
Preparing transaction: done
Verifying transaction: done
Executing transaction: - By downloading and using the CUDA Toolkit conda packages, you accept the terms and conditions of the CUDA End User License Agreement (EULA): https://docs.nvidia.com/cuda/eula/index.html

\ By downloading and using the cuDNN conda packages, you accept the terms and conditions of the NVIDIA cuDNN EULA -
  https://docs.nvidia.com/deeplearning/cudnn/sla/index.html

| Note: The hunspell package does not come with any dictionaries. You should
install at least one dictionary, e.g., hunspell-en.

done
Installing pip dependencies: / Ran pip subprocess with arguments:
['/home/PanXuehai/Miniconda3/envs/torchopt/bin/python', '-m', 'pip', 'install', '-U', '-r', '/home/PanXuehai/Projects/TorchOpt/condaenv.68eyfjkx.requirements.txt']
Pip subprocess output:
Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple
Collecting functorch
  Using cached https://pypi.tuna.tsinghua.edu.cn/packages/b9/88/64b7832173bf1448f86a26edc366914333a2119163f9cbf3a206aaee2bdc/functorch-0.2.0-cp38-cp38-manylinux1_x86_64.whl (26.7 MB)
Requirement already satisfied: torch<1.13,>=1.12 in /home/PanXuehai/Miniconda3/envs/torchopt/lib/python3.8/site-packages (from functorch->-r /home/PanXuehai/Projects/TorchOpt/condaenv.68eyfjkx.requirements.txt (line 1)) (1.12.0)
Requirement already satisfied: typing_extensions in /home/PanXuehai/Miniconda3/envs/torchopt/lib/python3.8/site-packages (from torch<1.13,>=1.12->functorch->-r /home/PanXuehai/Projects/TorchOpt/condaenv.68eyfjkx.requirements.txt (line 1)) (4.1.1)
Installing collected packages: functorch
Successfully installed functorch-0.2.0

done
#
# To activate this environment, use
#
#     $ conda activate torchopt
#
# To deactivate an active environment, use
#
#     $ conda deactivate

$ conda activate torchopt      

$ pip3 install -e .
Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple
Obtaining file:///home/PanXuehai/Projects/TorchOpt
Requirement already satisfied: torch==1.12 in /home/PanXuehai/Miniconda3/envs/torchopt/lib/python3.8/site-packages (from torchopt==0.4.1) (1.12.0)
Requirement already satisfied: jax[cpu]>=0.3 in /home/PanXuehai/Miniconda3/envs/torchopt/lib/python3.8/site-packages (from torchopt==0.4.1) (0.3.14)
Requirement already satisfied: numpy in /home/PanXuehai/Miniconda3/envs/torchopt/lib/python3.8/site-packages (from torchopt==0.4.1) (1.22.3)
Requirement already satisfied: graphviz in /home/PanXuehai/Miniconda3/envs/torchopt/lib/python3.8/site-packages (from torchopt==0.4.1) (0.16)
Requirement already satisfied: typing-extensions in /home/PanXuehai/Miniconda3/envs/torchopt/lib/python3.8/site-packages (from torchopt==0.4.1) (4.1.1)
Requirement already satisfied: absl-py in /home/PanXuehai/Miniconda3/envs/torchopt/lib/python3.8/site-packages (from jax[cpu]>=0.3->torchopt==0.4.1) (0.15.0)
Requirement already satisfied: etils[epath] in /home/PanXuehai/Miniconda3/envs/torchopt/lib/python3.8/site-packages (from jax[cpu]>=0.3->torchopt==0.4.1) (0.6.0)
Requirement already satisfied: opt-einsum in /home/PanXuehai/Miniconda3/envs/torchopt/lib/python3.8/site-packages (from jax[cpu]>=0.3->torchopt==0.4.1) (3.3.0)
Requirement already satisfied: scipy>=1.5 in /home/PanXuehai/Miniconda3/envs/torchopt/lib/python3.8/site-packages (from jax[cpu]>=0.3->torchopt==0.4.1) (1.7.3)
Requirement already satisfied: jaxlib==0.3.14 in /home/PanXuehai/Miniconda3/envs/torchopt/lib/python3.8/site-packages (from jax[cpu]>=0.3->torchopt==0.4.1) (0.3.14)
Requirement already satisfied: flatbuffers<3.0,>=1.12 in /home/PanXuehai/Miniconda3/envs/torchopt/lib/python3.8/site-packages (from jaxlib==0.3.14->jax[cpu]>=0.3->torchopt==0.4.1) (2.0)
Requirement already satisfied: six in /home/PanXuehai/Miniconda3/envs/torchopt/lib/python3.8/site-packages (from absl-py->jax[cpu]>=0.3->torchopt==0.4.1) (1.16.0)
Requirement already satisfied: importlib_resources in /home/PanXuehai/Miniconda3/envs/torchopt/lib/python3.8/site-packages (from etils[epath]->jax[cpu]>=0.3->torchopt==0.4.1) (5.2.0)
Requirement already satisfied: zipp in /home/PanXuehai/Miniconda3/envs/torchopt/lib/python3.8/site-packages (from etils[epath]->jax[cpu]>=0.3->torchopt==0.4.1) (3.8.0)
Installing collected packages: torchopt
  Running setup.py develop for torchopt
Successfully installed torchopt-0.4.1
```