### PR TITLE
fix(CMakeLists.txt): fix CUDA build for accelerated OP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix CUDA build for accelerated OP [@XuehaiPan](https://github.com/XuehaiPan) in [#53](https://github.com/metaopt/TorchOpt/pull/53).
+
 ### Removed
 
 ------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package(CUDA)
 if(CUDA_FOUND)
     message(STATUS "Found CUDA, enabling CUDA support.")
     enable_language(CUDA)
+    add_definitions(-D__CUDA_ENABLED__)
 
     cuda_select_nvcc_arch_flags(CUDA_ARCH_FLAGS All)
     list(APPEND CUDA_NVCC_FLAGS ${CUDA_ARCH_FLAGS})

--- a/src/adam_op/adam_op.cpp
+++ b/src/adam_op/adam_op.cpp
@@ -19,7 +19,7 @@
 #include <pybind11/stl.h>
 
 #include "include/adam_op/adam_op_impl_cpu.h"
-#if defined(__CUDACC__)
+#if defined(__CUDA_ENABLED__)
 #include "include/adam_op/adam_op_impl_cuda.cuh"
 #endif
 
@@ -30,7 +30,7 @@ TensorArray<3> adamForwardInplace(const torch::Tensor& updates,
                                   const pyfloat_t b2, const pyfloat_t eps,
                                   const pyfloat_t eps_root,
                                   const pyuint_t count) {
-#if defined(__CUDACC__)
+#if defined(__CUDA_ENABLED__)
   if (updates.device().is_cuda()) {
     return adamForwardInplaceCUDA(updates, mu, nu, b1, b2, eps, eps_root,
                                   count);
@@ -44,7 +44,7 @@ TensorArray<3> adamForwardInplace(const torch::Tensor& updates,
 }
 torch::Tensor adamForwardMu(const torch::Tensor& updates,
                             const torch::Tensor& mu, const pyfloat_t b1) {
-#if defined(__CUDACC__)
+#if defined(__CUDA_ENABLED__)
   if (updates.device().is_cuda()) {
     return adamForwardMuCUDA(updates, mu, b1);
   }
@@ -58,7 +58,7 @@ torch::Tensor adamForwardMu(const torch::Tensor& updates,
 
 torch::Tensor adamForwardNu(const torch::Tensor& updates,
                             const torch::Tensor& nu, const pyfloat_t b2) {
-#if defined(__CUDACC__)
+#if defined(__CUDA_ENABLED__)
   if (updates.device().is_cuda()) {
     return adamForwardNuCUDA(updates, nu, b2);
   }
@@ -75,7 +75,7 @@ torch::Tensor adamForwardUpdates(const torch::Tensor& new_mu,
                                  const pyfloat_t b1, const pyfloat_t b2,
                                  const pyfloat_t eps, const pyfloat_t eps_root,
                                  const pyuint_t count) {
-#if defined(__CUDACC__)
+#if defined(__CUDA_ENABLED__)
   if (new_mu.device().is_cuda()) {
     return adamForwardUpdatesCUDA(new_mu, new_nu, b1, b2, eps, eps_root, count);
   }
@@ -90,7 +90,7 @@ torch::Tensor adamForwardUpdates(const torch::Tensor& new_mu,
 TensorArray<2> adamBackwardMu(const torch::Tensor& dmu,
                               const torch::Tensor& updates,
                               const torch::Tensor& mu, const pyfloat_t b1) {
-#if defined(__CUDACC__)
+#if defined(__CUDA_ENABLED__)
   if (dmu.device().is_cuda()) {
     return adamBackwardMuCUDA(dmu, updates, mu, b1);
   }
@@ -105,7 +105,7 @@ TensorArray<2> adamBackwardMu(const torch::Tensor& dmu,
 TensorArray<2> adamBackwardNu(const torch::Tensor& dnu,
                               const torch::Tensor& updates,
                               const torch::Tensor& nu, const pyfloat_t b2) {
-#if defined(__CUDACC__)
+#if defined(__CUDA_ENABLED__)
   if (dnu.device().is_cuda()) {
     return adamBackwardNuCUDA(dnu, updates, nu, b2);
   }
@@ -123,7 +123,7 @@ TensorArray<2> adamBackwardUpdates(const torch::Tensor& dupdates,
                                    const torch::Tensor& new_nu,
                                    const pyfloat_t b1, const pyfloat_t b2,
                                    const pyuint_t count) {
-#if defined(__CUDACC__)
+#if defined(__CUDA_ENABLED__)
   if (dupdates.device().is_cuda()) {
     return adamBackwardUpdatesCUDA(dupdates, updates, new_mu, new_nu, b1, b2,
                                    count);


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [X] I have raised an issue to propose this change ([required](https://github.com/metaopt/TorchOpt/issues) for new features and bug fixes)

Fix CUDA build by manually adding a new macro `__CUDA_ENABLED__`. Macro `__CUDACC__` is not always defined by `nvcc`. See:

https://github.com/pytorch/pytorch/blob/4d3f7df33fa49a80b20ae328d5a5d71c655e3634/cmake/Modules_CUDA_fix/upstream/FindCUDA/run_nvcc.cmake#L190-L194

![image](https://user-images.githubusercontent.com/16078332/183360267-d66ba604-0b1c-4481-a811-8765f1a62f29.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] New environment (non-breaking change which adds 3rd-party environment)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://torchopt.readthedocs.io/en/latest/developer/contributing.html) guide (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format` (**required**)
- [X] I have checked the code using `make lint` (**required**)
- [X] I have ensured `make test` pass. (**required**)
