### PR TITLE
feat: add lazy-init for the optimizer states

### DIFF
--- a/torchopt/base.py
+++ b/torchopt/base.py
@@ -41,11 +41,21 @@ if TYPE_CHECKING:
     from torchopt.typing import OptState, Params, Updates
 
 
-__all__ = ['EmptyState', 'GradientTransformation', 'ChainedGradientTransformation', 'identity']
+__all__ = [
+    'EmptyState',
+    'UninitializedState',
+    'GradientTransformation',
+    'ChainedGradientTransformation',
+    'identity',
+]
 
 
 class EmptyState(NamedTuple):
     """An empty state for the simplest stateless transformations."""
+
+
+class UninitializedState(NamedTuple):
+    """A state that is not initialized yet."""
 
 
 class TransformInitFn(Protocol):  # pylint: disable=too-few-public-methods

--- a/torchopt/optim/meta/base.py
+++ b/torchopt/optim/meta/base.py
@@ -20,6 +20,7 @@ import torch
 import torch.nn as nn
 
 from torchopt import pytree
+from torchopt.base import UninitializedState
 from torchopt.typing import GradientTransformation, OptState, TupleOfTensors
 from torchopt.update import apply_updates
 from torchopt.utils import extract_module_containers
@@ -70,6 +71,8 @@ class MetaOptimizer:
         ):
             flat_params: TupleOfTensors
             flat_params, container_treespec = pytree.tree_flatten_as_tuple(param_container)  # type: ignore[arg-type]
+            if isinstance(state, UninitializedState):
+                state = self.impl.init(flat_params)
             grads = torch.autograd.grad(
                 loss,
                 flat_params,
@@ -95,10 +98,8 @@ class MetaOptimizer:
     def add_param_group(self, module: nn.Module) -> None:
         """Add a param group to the optimizer's :attr:`state_groups`."""
         params_container = extract_module_containers(module, with_buffers=False)[0]
-        flat_params: TupleOfTensors = tuple(pytree.tree_leaves(params_container))  # type: ignore[arg-type]
-        optimizer_state = self.impl.init(flat_params)
         self.param_containers_groups.append(params_container)
-        self.state_groups.append(optimizer_state)
+        self.state_groups.append(UninitializedState())
 
     def state_dict(self) -> Tuple[OptState, ...]:
         """Extract the references of the optimizer states.

--- a/torchopt/optim/meta/base.py
+++ b/torchopt/optim/meta/base.py
@@ -65,7 +65,7 @@ class MetaOptimizer:
                 The loss that is used to compute the gradients to the network parameters.
         """
         # Step parameter only
-        for i, (param_container, new_state) in enumerate(
+        for i, (param_container, state) in enumerate(
             zip(self.param_containers_groups, self.state_groups)
         ):
             flat_params: TupleOfTensors
@@ -78,7 +78,7 @@ class MetaOptimizer:
             )
             updates, new_state = self.impl.update(
                 grads,
-                new_state,
+                state,
                 params=flat_params,
                 inplace=False,
             )

--- a/torchopt/transform/scale_by_adam.py
+++ b/torchopt/transform/scale_by_adam.py
@@ -38,6 +38,7 @@ from typing import NamedTuple
 import torch
 
 from torchopt import pytree
+from torchopt.accelerated_op import AdamOp
 from torchopt.base import GradientTransformation
 from torchopt.transform.utils import inc_count, tree_map_flat, update_moment
 from torchopt.typing import SequenceOfTensors, Updates
@@ -264,8 +265,6 @@ def _scale_by_accelerated_adam(
     if not 0.0 <= b2 < 1.0:
         raise ValueError(f'Invalid beta parameter at index 1: {b2}')
     # pylint: enable=unneeded-not
-
-    from torchopt.accelerated_op import AdamOp  # pylint: disable=import-outside-toplevel
 
     if already_flattened:
         tree_map = tree_map_flat

--- a/torchopt/utils.py
+++ b/torchopt/utils.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Utilities for TorchOpt."""
 
+import copy
 import itertools
 from typing import (
     TYPE_CHECKING,
@@ -429,9 +430,7 @@ def module_clone(
     if device is not None:
         device = torch.device(device)
 
-    # pylint: disable=import-outside-toplevel
-    import copy
-
+    # pylint: disable-next=import-outside-toplevel
     from torchopt.optim.meta.base import MetaOptimizer
 
     if isinstance(target, (nn.Module, MetaOptimizer)):


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [X] I have raised an issue to propose this change ([required](https://github.com/metaopt/torchopt/issues) for new features and bug fixes)

Fixes #116

Moving module to another device after defining the meta-optimizer:

```python
module = ...
torchopt.MetaAdam(module)
module = module.cuda()
```

The optimizer `state` will be lazily initialized on the first `step` call.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://torchopt.readthedocs.io/en/latest/developer/contributing.html) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
