### PR TITLE
Fix overloading of extract_state_dict

### DIFF
--- a/torchopt/utils.py
+++ b/torchopt/utils.py
@@ -99,6 +99,7 @@ def extract_state_dict(
     by: CopyMode = 'reference',
     device: Device | None = None,
     with_buffers: bool = True,
+    detach_buffers: bool = False,
     enable_visual: bool = False,
     visual_prefix: str = '',
 ) -> ModuleState:  # pragma: no cover
@@ -111,7 +112,6 @@ def extract_state_dict(
     *,
     by: CopyMode = 'reference',
     device: Device | None = None,
-    with_buffers: bool = True,
     enable_visual: bool = False,
     visual_prefix: str = '',
 ) -> tuple[OptState, ...]:  # pragma: no cover


### PR DESCRIPTION
## Description

Added detach_buffers keyword arg to the nn.Module version of extract_state_dict and removed with_buffers from the MetaOptimizer version of extract_state_dict.

## Motivation and Context

Fixes #161

- [x] I have raised an issue to propose this change ([required](https://github.com/metaopt/torchopt/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://torchopt.readthedocs.io/en/latest/developer/contributing.html) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)

Comment: there currently are no tests for type checking, so there weren't any tests that needed updating.